### PR TITLE
fix: Remove configurable plugin URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,20 @@ otherwise, it'll provide versions from the `netskope_mock` package.
 
 [^1]: Netskope either uses GRC as an umbrella term for some of its products,
     including ARE, or, more likely, used to refer to the ARE product as GRC.
+
+## Tests
+
+### Unit Tests
+
+```bash
+$ poetry run pytest tests
+
+```
+
+### Integration Tests
+
+ - `VISOTRUST_EMAIL` defaults to `admin@visotrust.com`
+
+```bash
+$ VISOTRUST_URL=... VISOTRUST_TOKEN=... poetry run pytest integration
+```

--- a/are_plugin/main.py
+++ b/are_plugin/main.py
@@ -23,6 +23,7 @@ from .are import (
 from .client import util
 from .client.model import RelationshipCreateUpdateInput
 from .proto import Application
+from .url import BASE_URL
 
 VISOTRUST_CONCURRENT = 1
 
@@ -110,7 +111,7 @@ class VTPluginARE(PluginBase):
         if sys.modules.get('netskope'):
             args.update(
                 proxies=self.proxy,
-                verify=self.ssl_validation and config['url'].startswith('https'),
+                verify=self.ssl_validation and BASE_URL.startswith('https'),
             )
         return args
 
@@ -118,7 +119,7 @@ class VTPluginARE(PluginBase):
         self, session: FuturesSession, token: str, create: RelationshipCreateUpdateInput
     ) -> Future:
         return session.post(
-            f"{self.configuration['url']}/api/v1/relationships",
+            f"{BASE_URL}/api/v1/relationships",
             headers={
                 'Authorization': f"Bearer {token}",
                 'Content-Type': 'application/json',
@@ -190,12 +191,11 @@ class VTPluginARE(PluginBase):
                 )
             token = config.get('token', '')
             email = config.get('email', '')
-            url = config.get('url', '')
-            if not (token and email and url):
+            if not (token and email):
                 raise ValueError('Missing keys.')
 
-            url = f'{url}/api/v1/relationships'
-            self.logger.info(f'Validating against url {url}.')
+            url = f'{BASE_URL}/api/v1/relationships'
+            self.logger.info(f'Validating against url {BASE_URL}.')
             resp = requests.options(
                 url,
                 headers={'Authorization': f"Bearer {token}"},

--- a/are_plugin/manifest.json
+++ b/are_plugin/manifest.json
@@ -1,33 +1,25 @@
 {
-    "name": "VISOTrustARE",
+    "name": "VISO TRUST ARE",
     "id": "are_plugin",
     "version": "0.0.1",
     "patch_supported": true,
-    "description": "This plugin creates vendor relationships in VISO Trust.",
+    "description": "This plugin creates vendor relationships in VISO TRUST.",
     "configuration": [
         {
-            "label": "VISOTrust URL",
-            "key": "url",
-            "type": "text",
-            "default": "https://visotrust.com",
-            "mandatory": true,
-            "description": "VISOTrust instance URL."
-        },
-        {
-            "label": "VISO Business Owner Email",
+            "label": "VISO TRUST Business Owner Email",
             "key": "email",
             "type": "text",
             "default": "",
             "mandatory": true,
-            "description": "VISOTrust client email address."
+            "description": "VISO TRUST client email address."
         },
         {
-            "label": "VISO API Token",
+            "label": "VISO TRUST API Token",
             "key": "token",
             "type": "password",
             "default": "",
             "mandatory": true,
-            "description": "API Token."
+            "description": "VISO TRUE API Token."
         }
     ]
 }

--- a/are_plugin/url.py
+++ b/are_plugin/url.py
@@ -1,0 +1,3 @@
+import os
+
+BASE_URL = os.environ.get('VISOTRUST_URL', 'https://app.visotrust.com')

--- a/integration/test_plugin.py
+++ b/integration/test_plugin.py
@@ -1,0 +1,54 @@
+import hashlib
+import os
+from datetime import datetime
+
+import requests
+
+from are_plugin.main import CCLTag, VTPluginARE
+from are_plugin.netskope_model import Application
+from are_plugin.url import BASE_URL
+
+EMAIL = os.environ.get('VISOTRUST_EMAIL', 'admin@visotrust.com')
+
+DISC_DOMAINS = ['xyz.net']
+STEER_DOMAINS = ['xyz.com']
+NAME = hashlib.new('sha1', datetime.now().isoformat().encode('utf-8')).hexdigest()
+VENDOR = f'v{NAME}'
+TAGS = [f't{NAME}']
+
+
+app_args = {
+    'applicationId': 1,
+    'applicationName': NAME,
+    'vendor': VENDOR,
+    'customTags': TAGS,
+    'deepLink': '',
+    'users': (),
+    'cci': 0,
+    'discoveryDomains': DISC_DOMAINS,
+    'steeringDomains': STEER_DOMAINS,
+}
+
+TOKEN = os.environ['VISOTRUST_TOKEN']
+
+
+def check_vendor_matches(app, expected_ccl):
+    resp = requests.get(
+        f'{BASE_URL}/api/v1/relationships', headers={'Authorization': f'Bearer {TOKEN}'}
+    )
+    resp.raise_for_status()
+    matches = 0
+    for v in resp.json():
+        if v['name'] == app.vendor:
+            matches += 1
+            assert v['tags'] == [expected_ccl]
+    assert matches == 1
+
+
+plugin = VTPluginARE(config={'token': TOKEN, 'email': EMAIL})
+
+
+def test_plugin():
+    app = Application(**app_args)
+    assert plugin.push([app, app, app], None).success
+    check_vendor_matches(app, CCLTag.POOR)

--- a/tests/test_are_plugin.py
+++ b/tests/test_are_plugin.py
@@ -9,6 +9,7 @@ from requests import Response
 
 from are_plugin.main import CCLTag, VTPluginARE
 from are_plugin.netskope_model import Application
+from are_plugin.url import BASE_URL
 
 
 class Response(BaseModel):
@@ -38,7 +39,6 @@ app = Application(**app_args)
 config = {
     'token': string.ascii_lowercase,
     'email': 'admin@visotrust.com',
-    'url': 'http://localhost',
     'max_cci': 100,
 }
 
@@ -68,7 +68,7 @@ def post():
 def test_http(post):
     VTPluginARE(config=config).push([app], None)
 
-    assert post.call_args.args[0] == f'{config["url"]}/api/v1/relationships'
+    assert post.call_args.args[0] == f'{BASE_URL}/api/v1/relationships'
     args = post.call_args.kwargs
     assert args['headers']['Authorization'] == f'Bearer {string.ascii_lowercase}'
     j = json.loads(args['data'])


### PR DESCRIPTION
This removes the plugin from `manifest.json` and adds an integration test to make sure that the plugin more or less works without it.